### PR TITLE
pre2: Support amstrad cpc/cpc +

### DIFF
--- a/p2/unpack.c
+++ b/p2/unpack.c
@@ -327,7 +327,7 @@ uint8_t *unpack(FILE *in, int *uncompressed_size) {
 	const uint16_t sig = fread_le16(in);
 	fseek(in, 0, SEEK_SET);
 	if (sig == 0x4CB4) {
-		memset(&uneat, 0, sizeof(unsqz));
+		memset(&uneat, 0, sizeof(uneat));
 		*uncompressed_size = unpack_eat(in, &uneat);
 		return uneat.dst;
 	} else if ((sig >> 8) == 0x10) {


### PR DESCRIPTION
Hi, It would wonderful could choose what graphics to choose.
Although Dos vga is wonderful, the port done for amstrad cpc / cpc + is amazing being one of the best and more beautiful games on the system.
It had several modes, the cpc with less colors and software sprites and cpc+, being one of the few games which used the extra hardware sprites 
Thanks 